### PR TITLE
handle zero height elements at the top of the page (bottom 0) correctly

### DIFF
--- a/dom/index.js
+++ b/dom/index.js
@@ -43,7 +43,7 @@ function kebab (str) {
 function isInViewPort (el) {
   if (el && el.parentElement) {
     const { top, bottom } = el.getBoundingClientRect()
-    return top < window.innerHeight && bottom > 0
+    return top < window.innerHeight && bottom >= 0
   }
   return false
 }

--- a/test/dom.js
+++ b/test/dom.js
@@ -56,8 +56,8 @@ describe('dom', function () {
 
     it('should fire if the element is in view and has no height', function () {
       const stub = sinon.stub()
-      const four = document.createElement('div')
-      container.prepend(four)
+      container.insertAdjacentHTML('afterbegin', '<div id="test-4"></div>')
+      const four = container.querySelector('#test-4')
       onEnterViewport(four, stub)
       expect(stub.calledOnce).to.eql(true)
     })

--- a/test/dom.js
+++ b/test/dom.js
@@ -54,6 +54,14 @@ describe('dom', function () {
       expect(stub.calledOnce).to.eql(true)
     })
 
+    it('should fire if the element is in view and has no height', function () {
+      const stub = sinon.stub()
+      const four = document.createElement('div')
+      container.prepend(four)
+      onEnterViewport(four, stub)
+      expect(stub.calledOnce).to.eql(true)
+    })
+
     describe('when the element is below the viewport', function () {
       beforeEach(() => {
         one.style.height = window.innerHeight + 'px'


### PR DESCRIPTION
If you have an el at the top of the page with no height, its client rect bottom value will be zero. This is fine, but the isInViewPort function will return false where it should return true