### PR TITLE
Handle elements being above the viewport due to minus margins

### DIFF
--- a/dom/index.js
+++ b/dom/index.js
@@ -42,13 +42,18 @@ function kebab (str) {
 
 function isInViewPort (el) {
   if (el && el.parentElement) {
-    const { top, bottom, height } = el.getBoundingClientRect()
-    const isAboveTop = height > 0 && top + height <= 0
-    return isAboveTop
-      ? false
-      : top < window.innerHeight && bottom >= 0
+    const { top, bottom } = el.getBoundingClientRect()
+    const isAboveWindowsBottom = top < window.innerHeight
+    const isBelowWindowsTop =
+      top === bottom
+        ? // If both bottom and top are at 0px
+          // the element is entirely inside the viewport
+          bottom >= 0
+        : // If the element has height, when bottom is at 0px
+          // the element is above the window
+          bottom > 0
+    return isAboveWindowsBottom && isBelowWindowsTop
   }
-  return false
 }
 
 function onAnyEnterViewport (els, fn) {

--- a/dom/index.js
+++ b/dom/index.js
@@ -43,7 +43,14 @@ function kebab (str) {
 function isInViewPort (el) {
   if (el && el.parentElement) {
     const { top, bottom } = el.getBoundingClientRect()
-    const isAboveWindowsBottom = top < window.innerHeight
+    const isAboveWindowsBottom =
+      top === bottom
+        ? // If both bottom and top are at window.innerHeight
+          // the element is entirely inside the viewport
+          top <= window.innerHeight
+        : // If the element has height, when top is at window.innerHeight
+          // the element is below the window
+          top < window.innerHeight
     const isBelowWindowsTop =
       top === bottom
         ? // If both bottom and top are at 0px

--- a/dom/index.js
+++ b/dom/index.js
@@ -42,8 +42,11 @@ function kebab (str) {
 
 function isInViewPort (el) {
   if (el && el.parentElement) {
-    const { top, bottom } = el.getBoundingClientRect()
-    return top < window.innerHeight && bottom >= 0
+    const { top, bottom, height } = el.getBoundingClientRect()
+    const isAboveTop = height > 0 && top + height <= 0
+    return isAboveTop
+      ? false
+      : top < window.innerHeight && bottom >= 0
   }
   return false
 }

--- a/test/dom.js
+++ b/test/dom.js
@@ -102,7 +102,7 @@ describe('dom', function () {
       })
     })
 
-    describe('when the element is above the viewport', function () {
+    describe('when the element is above the viewport due to scroll position', function () {
       beforeEach(() => {
         three.style.height = window.innerHeight + 'px'
         return scroller(20)
@@ -130,6 +130,27 @@ describe('dom', function () {
             .then(() => wait(100))
             .then(() => expect(stub.calledTwice).to.eql(true))
         })
+      })
+    })
+
+    describe('when the element is above the viewport due to negative margins', function () {
+      let zero
+      beforeEach(() => {
+        container.innerHTML = `<div id='test-0' style='height:10px;margin-top:-10px'>test 0</div>`
+        zero = container.querySelector('#test-0')
+      })
+
+      it('should not fire', function () {
+        const stub = sinon.stub()
+        onEnterViewport(zero, stub)
+        expect(stub.called).to.eql(false)
+      })
+
+      it('should fire when the element becomes viewable', function () {
+        const stub = sinon.stub()
+        zero.style['margin-top'] = '0'
+        onEnterViewport(zero, stub)
+        expect(stub.called).to.eql(true)
       })
     })
   })

--- a/test/dom.js
+++ b/test/dom.js
@@ -148,7 +148,7 @@ describe('dom', function () {
 
       it('should fire when the element becomes viewable', function () {
         const stub = sinon.stub()
-        zero.style['margin-top'] = '0'
+        zero.style.marginTop = '0'
         onEnterViewport(zero, stub)
         expect(stub.called).to.eql(true)
       })


### PR DESCRIPTION
onEnterViewport fires incorrectly if the target el is above the viewport due to having a minus margin greater than or equal to its height. This is the case on the notice bar at the top of this site https://int.cariuma.com/