### PR TITLE
Optional target for the scroll listener in onImpression

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ function cb () {
 }
 ```
 
-## onEnterViewport(el, fn)
+## onEnterViewport(el, fn, [scrollTargetEl])
 
 Calls callback when `el` enters the viewport, returns a function that cancels and removes any event listeners. If you omit the callback, the function returns a promise. You should use restoreAll to restore in this case.
+*It accepts a third optional parameter `scrollTargetEl` which represents the element where the scroll listener will be attached. If not specified `window` will be used.*
 
 e.g.
 

--- a/dom/index.js
+++ b/dom/index.js
@@ -71,7 +71,7 @@ function onAnyEnterViewport (els, fn) {
   })
 }
 
-function onEnterViewport (el, fn) {
+function onEnterViewport (el, fn, scrollTargetEl = window) {
   if (_.isArray(el)) {
     return onAnyEnterViewport(el, fn)
   }
@@ -83,12 +83,12 @@ function onEnterViewport (el, fn) {
 
   const handleScroll = _.debounce(() => {
     if (isInViewPort(el)) {
-      window.removeEventListener('scroll', handleScroll)
+      scrollTargetEl.removeEventListener('scroll', handleScroll)
       fn()
     }
   }, 50)
-  window.addEventListener('scroll', handleScroll)
-  return once(() => window.removeEventListener('scroll', handleScroll))
+  scrollTargetEl.addEventListener('scroll', handleScroll)
+  return once(() => scrollTargetEl.removeEventListener('scroll', handleScroll))
 }
 
 function replace (target, el) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@qubit/buble-loader": "^0.5.1",
         "chai": "^4.2.0",
         "healthier": "^4.0.0",
-        "is-docker": "^2.2.1",
         "istanbul-instrumenter-loader": "^3.0.1",
         "karma": "^6.3.2",
         "karma-chrome-launcher": "^3.1.0",
@@ -5773,21 +5772,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -10913,6 +10897,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -16233,12 +16218,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
-    },
-    "is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true
     },
     "is-extendable": {


### PR DESCRIPTION
Added a third optional parameter to `onImpression()` helper so that when it is passed then we use that element to attach the `scroll` listener onto, as opposite to `window`. If it is not specified, then `window` is used as the default.